### PR TITLE
Fix poetry installation to be compliant with official doc

### DIFF
--- a/fast-api-celery/Dockerfile.base
+++ b/fast-api-celery/Dockerfile.base
@@ -8,10 +8,11 @@ WORKDIR /app
 COPY . .
 
 RUN apt update -y && apt upgrade -y && apt install curl -y
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-RUN $HOME/.poetry/bin/poetry config virtualenvs.create false 
-RUN $HOME/.poetry/bin/poetry install --no-dev 
-RUN $HOME/.poetry/bin/poetry export -f requirements.txt >> requirements.txt
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python -
+ENV PATH=/opt/poetry/bin:$PATH
+RUN poetry config virtualenvs.create false 
+RUN poetry install --no-dev 
+RUN poetry export -f requirements.txt >> requirements.txt
 
 #
 # Prod image


### PR DESCRIPTION
I've update the installation of poetry in the Dockerfile, since according to the [official doc](https://python-poetry.org/docs/#installing-with-the-official-installer) the `get-poetry.py` installer has been deprecated and removed.